### PR TITLE
Ramlversion

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -6,6 +6,6 @@ contributors:
 
 - `Hynek Schlawack <https://github.com/hynek>`_
 - `Matt Montag <https://github.com/mmontag>`_
-
+- `Pierre Tardy  <https://github.com/tardyp>`_
 
 .. _`Lynn Root`: https://github.com/econchick

--- a/ramlfications/errors.py
+++ b/ramlfications/errors.py
@@ -59,3 +59,7 @@ class LoadRAMLError(Exception):
 
 class MediaTypeError(Exception):
     pass
+
+
+class InvalidVersionError(Exception):
+    pass

--- a/ramlfications/parser/__init__.py
+++ b/ramlfications/parser/__init__.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function
 import attr
 
 from ramlfications.errors import InvalidRAMLError
+from ramlfications.errors import InvalidVersionError
 from ramlfications.utils.common import _get
 
 from .main import (
@@ -29,7 +30,12 @@ def parse_raml(loaded_raml, config):
     # Postpone validating the root node until the end; otherwise,
     # we end up with duplicate validation exceptions.
     attr.set_run_validators(False)
-
+    raml_versions = config['raml_versions']
+    if loaded_raml._raml_version not in raml_versions:
+        raise InvalidVersionError(
+            "RAML version not allowed in config {0}: allowed: {1}".format(
+                loaded_raml._raml_version, ", ".join(raml_versions)
+            ))
     root = create_root(loaded_raml, config)
     attr.set_run_validators(validate)
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -12,6 +12,7 @@ UPDATE = os.path.join(PAR_DIR + '/data/update/')
 JSONREF = os.path.join(PAR_DIR + '/data/jsonref/')
 
 V020EXAMPLES = os.path.join(PAR_DIR + '/data/v020examples/')
+RAML10EXAMPLES = os.path.join(PAR_DIR + '/data/raml10examples/')
 
 
 class AssertNotSetError(Exception):

--- a/tests/data/examples/invalid_yaml.yaml
+++ b/tests/data/examples/invalid_yaml.yaml
@@ -1,3 +1,4 @@
+#%RAML 0.8
 [main]
 validate = True
 production = True

--- a/tests/data/raml10examples/basicheader.raml
+++ b/tests/data/raml10examples/basicheader.raml
@@ -1,0 +1,2 @@
+#%RAML 1.0
+title: My API

--- a/tests/data/raml10examples/test_config.ini
+++ b/tests/data/raml10examples/test_config.ini
@@ -1,4 +1,5 @@
 [main]
 validate = False
 production = True
-
+[custom]
+raml_versions = 1.0

--- a/tests/data/raml10examples/test_config.ini
+++ b/tests/data/raml10examples/test_config.ini
@@ -1,0 +1,4 @@
+[main]
+validate = False
+production = True
+

--- a/tests/raml10tests/test_basic.py
+++ b/tests/raml10tests/test_basic.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2015 Spotify AB
+from __future__ import absolute_import, division, print_function
+
+import os
+
+import pytest
+
+from ramlfications.parser import parse_raml
+from ramlfications.config import setup_config
+from ramlfications.utils import load_file
+
+
+from tests.base import RAML10EXAMPLES
+
+
+# Security scheme properties:
+# name, raw, type, described_by, desc, settings, config, errors
+
+
+@pytest.fixture(scope="session")
+def api():
+    ramlfile = os.path.join(RAML10EXAMPLES, "basicheader.raml")
+    loaded_raml = load_file(ramlfile)
+    conffile = os.path.join(RAML10EXAMPLES, "test_config.ini")
+    config = setup_config(conffile)
+    return parse_raml(loaded_raml, config)
+
+
+def test_basic(api):
+    assert api.raw._raml_version == "1.0"
+    assert api.title == "My API"

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -376,3 +376,13 @@ def test_empty_mapping_sec_scheme_settings():
            "definition.",)
     assert _error_exists(e.value.errors, errors.InvalidSecuritySchemeError,
                          msg)
+
+
+def test_invalid_raml_version():
+    _raml = "invalid-version.raml"
+    raml = load_raml(_raml)
+    config = load_config("valid-config.ini")
+    with pytest.raises(errors.InvalidVersionError) as e:
+        validate(raml, config)
+    msg = "RAML version not allowed in config 0.9: allowed: 0.8"
+    assert msg in e.value.args


### PR DESCRIPTION
Here is a first PR to make myself confident with the code.

This adds capability to read the ramlversion in the file, and choke if it is not what is configured.

This adds new directory for shiny new unit tests for testing 1.0 features.

I do this PR against your wip branch, which looks like do not have all test passing (unless I'm missing something)
especially test_validate does not work for me, half of the validation do not raise. e.g:

```
tests/test_validate.py:316: Failed
________________________________________________________________________________________________________ test_invalid_response_code ________________________________________________________________________________________________________

    def test_invalid_response_code():
        raml = load_raml("invalid-response-code.raml")
        config = load_config("valid-config.ini")
        with raises as e:
>           validate(raml, config)
E           Failed: DID NOT RAISE

tests/test_validate.py:327: Failed
```
